### PR TITLE
dbussy: release reference to pending_done in PendingCall.await_reply

### DIFF
--- a/dbussy.py
+++ b/dbussy.py
@@ -4918,6 +4918,7 @@ class PendingCall :
         self.set_notify(pending_done, weak_ref(self))
           # avoid reference circularity self → pending_done → self
         reply = await done
+        self.set_notify(None, None)
         return \
             reply
     #end await_reply


### PR DESCRIPTION
Proposed fix for https://github.com/ldo/dbussy/issues/21