### PR TITLE
Fix to allow unregistering of a single specific interface

### DIFF
--- a/ravel.py
+++ b/ravel.py
@@ -594,7 +594,7 @@ class Connection(dbus.TaskKeeper) :
                 component = next(levels, None)
                 if component == None :
                     if interface != None :
-                        interfaces = [level.interfaces[interface._interface_name]]
+                        interfaces = [interface._interface_name]
                     else :
                         interfaces = set(level.interfaces.keys())
                     #end if


### PR DESCRIPTION
Proposed fix for issue #31 