### PR TITLE
Allow working with P2P busses

### DIFF
--- a/ravel.py
+++ b/ravel.py
@@ -227,7 +227,6 @@ class Connection(dbus.TaskKeeper) :
             self._server_dispatch = None # for registered classes that field method calls
             self._managed_objects = None
             unique_name = connection.bus_unique_name
-            assert unique_name != None, "connection not yet registered"
             self.bus_names_acquired = {unique_name}
             self.bus_names_pending = set()
             self._registered_bus_names_listeners = False

--- a/ravel.py
+++ b/ravel.py
@@ -630,7 +630,8 @@ class Connection(dbus.TaskKeeper) :
         listeners = entry.signal_listeners
         rulekey = _signal_key(fallback, interface, name)
         if rulekey not in listeners :
-            self.connection.bus_add_match(_signal_rule(path, fallback, interface, name))
+            if self.connection.bus_unique_name is not None:
+                self.connection.bus_add_match(_signal_rule(path, fallback, interface, name))
             listeners[rulekey] = []
         #end if
         listeners[rulekey].append(func)
@@ -653,11 +654,12 @@ class Connection(dbus.TaskKeeper) :
                 #end try
                 if len(listeners) == 0 :
                     ignore = dbus.Error.init()
-                    self.connection.bus_remove_match \
-                      (
-                        _signal_rule(path, fallback, interface, name),
-                        ignore
-                      )
+                    if self.connection.bus_unique_name is not None:
+                        self.connection.bus_remove_match \
+                          (
+                            _signal_rule(path, fallback, interface, name),
+                            ignore
+                          )
                     del signal_listeners[rulekey]
                       # as a note to myself that I will need to call bus_add_match
                       # if a new listener is added


### PR DESCRIPTION
This allow dbussy to connect to a pulseaudio dbus socket.

peer-to-peer busses act a bit differently and need to be handled as so.

ref: https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/Developer/Clients/DBus/
ref: https://github.com/mvidner/ruby-dbus/issues/44
ref: https://github.com/altdesktop/python-dbus-next/issues/20

sample code:
``` python
import ravel
import dbussy

NAME = 'org.pulseaudio.Server'
PATH = '/org/pulseaudio/server_lookup1'
INTERFACE = 'org.PulseAudio.ServerLookup1'

session = ravel.session_bus()
interface = session[NAME][PATH].get_interface(dbussy.DBUS.INTERFACE_PROPERTIES)
method = getattr(interface, 'Get')
result = method(INTERFACE, 'Address')
first = next(iter(result or []), None)
address = first[1]

BUS = ravel.connect_server(address)

CORE_PATH = '/org/pulseaudio/core1'
CORE_INTERFACE = 'org.PulseAudio.Core1'

@ravel.signal(name='NewSink', in_signature='o', arg_keys=['name'], path_keyword='path')
def on_new_sink(name, path):
    if path == CORE_PATH:
        print(name)

BUS.listen_signal(path=CORE_PATH, interface=CORE_INTERFACE, fallback=True, func=on_new_sink, name='NewSink')
```

without this PR
```
Traceback (most recent call last):
  File "/home/lukas/Documents/git/dbussy/test-ravel.py", line 15, in <module>
    BUS = ravel.connect_server(address)
  File "/home/lukas/.local/lib/python3.9/site-packages/ravel.py", line 1512, in connect_server
    Connection(dbus.Connection.open(address, private = False)) \
  File "/home/lukas/.local/lib/python3.9/site-packages/ravel.py", line 230, in __new__
    assert unique_name != None, "connection not yet registered"
AssertionError: connection not yet registered
```
and
```
Traceback (most recent call last):
  File "/home/lukas/Documents/git/dbussy/test-ravel.py", line 25, in <module>
    BUS.listen_signal(path=CORE_PATH, interface=CORE_INTERFACE, fallback=True, func=on_new_sink, name='NewSink')
  File "/home/lukas/.local/lib/python3.9/site-packages/ravel.py", line 631, in listen_signal
    self.connection.bus_add_match(_signal_rule(path, fallback, interface, name))
  File "/home/lukas/.local/lib/python3.9/site-packages/dbussy.py", line 3240, in bus_add_match
    my_error.raise_if_set()
  File "/home/lukas/.local/lib/python3.9/site-packages/dbussy.py", line 5020, in raise_if_set
    raise DBusError(self.name, self.message)
dbussy.DBusError: org.freedesktop.DBus.Error.UnknownMethod -- Method "AddMatch" with signature "s" on interface "org.freedesktop.DBus" doesn't exist
```


