### PR TITLE
Fix example about org.freedesktop.Notifications

### DIFF
--- a/README
+++ b/README
@@ -338,7 +338,7 @@ is possible to pass them to the method call by keyword:
             body = "DBussy works!",
             actions = [],
             hints = {},
-            timeout = 5000,
+            expire_timeout = 5000,
           )
 
 (But note that the argument names might differ, depending on your


### PR DESCRIPTION
The timeout argument should be called `expire_timeout` as per the [spec](https://developer.gnome.org/notification-spec/).